### PR TITLE
Post-rename CI fixes + repo metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,30 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot version updates.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Python dependencies (pyproject.toml + uv.lock, managed by uv)
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "dev"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions used in the workflows (checkout, setup-python, setup-uv, ...)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       # Run when documentation changes
       - 'docs/**'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ on:
     types: [published]
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read
@@ -65,7 +65,7 @@ jobs:
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/master' && github.event_name != 'release'
+    if: github.ref == 'refs/heads/main' && github.event_name != 'release'
     steps:
       - name: Download distributions
         uses: actions/download-artifact@v4

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <p align="center">
   <a href="https://julioanzaldo.github.io/telemetry-anomdet/"><img alt="Documentation" src="https://img.shields.io/badge/docs-online-blue"></a>
   <a href="https://test.pypi.org/project/telemetry-anomdet/"><img alt="Test PyPI" src="https://img.shields.io/badge/Test-PyPI-yellow"></a>
-  <a href="https://github.com/JulioAnzaldo/telemetry-anomdet/issues"><img alt="GitHub Issues" src="https://img.shields.io/github/issues/JulioAnzaldo/telemetry-anomdet"></a>
-  <a href="https://github.com/JulioAnzaldo/telemetry-anomdet/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/JulioAnzaldo/telemetry-anomdet"></a>
+  <a href="https://github.com/JulioAnzaldo/telemetry-anomdet/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/JulioAnzaldo/telemetry-anomdet/actions/workflows/ci.yml/badge.svg?branch=main"></a>
+  <a href="https://github.com/JulioAnzaldo/telemetry-anomdet/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue"></a>
 </p>
 
 **telemetry-anomdet** is an open-source anomaly detection toolkit for spacecraft telemetry. It runs a stacking ensemble of classical and deep learning detectors with per-channel SHAP attribution, SymTorch symbolic fault expressions, and LLM-generated diagnostic reports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "telemetry-anomdet"
-version = "0.0.5"
+version = "0.0.51"
 description = "Telemetry anomaly detection toolkit with preprocessing, feature extraction, and unsupervised models."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -25,8 +25,12 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries",
-  "Development Status :: 1 - Planning",
-  "License :: OSI Approved :: Apache Software License"
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Intended Audience :: Science/Research",
+  "Intended Audience :: Developers",
+  "Development Status :: 3 - Alpha",
+  "License :: OSI Approved :: Apache Software License",
+  "Typing :: Typed"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Follow-up cleanup after the `master` to `main` default-branch rename, plus repo metadata accuracy.

## Changes
- **ci:** repoint `docs.yml` and `publish.yml` triggers from `master` to `main` (they silently stopped firing after the rename).
- **docs(readme):** swap the flaky shields.io `/github/` badges (failing with *"Unable to select next GitHub token from pool"* shields.io rate-limiting) for GitHub's native CI status badge + a static Apache-2.0 license badge.
- **ci(dependabot):** replace the empty placeholder ecosystem with real `uv` (Python deps) and `github-actions` configs, grouped, targeting `dev`.
- **chore(metadata):** bump `Development Status :: 1 - Planning` to `3 - Alpha`; add Scientific/Engineering :: AI, Intended Audience, and `Typing :: Typed` (py.typed is shipped).

No source or test changes.