### PR TITLE
Point-adjusted F1 + SMAP benchmark

### DIFF
--- a/examples/smap_benchmark.py
+++ b/examples/smap_benchmark.py
@@ -1,0 +1,150 @@
+"""
+SMAP classical-baseline benchmark.
+
+Runs the PCA + KMeans ensemble across SMAP channels and reports point-adjusted
+F1, the standard SMAP metric (comparable to telemanom and MEMTO). For each
+channel it trains on the nominal train split and scores the test split.
+
+Scores are swept over a range of thresholds and the best point-adjusted F1 is
+reported. That is the standard SMAP "best F1" protocol (telemanom / MEMTO report
+their numbers the same way), which makes the comparison fair. Note the threshold
+is selected against the labels, so treat it as an oracle-threshold upper bound,
+not a deployable operating point.
+
+Point it at a local copy of the SMAP dataset (telemanom format), same as
+examples/smap_demo.py:
+    TAD_SMAP_DIR    -> directory containing train/ and test/ .npy files
+    TAD_SMAP_LABELS -> labeled_anomalies.csv (optional; searched from DATA_DIR)
+    TAD_SMAP_MAX_CHANNELS -> limit the run (default: all SMAP channels)
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+import numpy as np
+from sklearn.exceptions import ConvergenceWarning
+
+from telemetry_anomdet.evaluation import best_point_adjusted_f1, windows_to_point_scores
+from telemetry_anomdet.feature_extraction.features import make_feature_table
+from telemetry_anomdet.ingest import anomaly_point_mask, load_smap, load_smap_labels
+from telemetry_anomdet.models.ensemble import AnomalyEnsemble
+from telemetry_anomdet.models.unsupervised import KMeansAnomaly, PCAAnomaly
+from telemetry_anomdet.preprocessing import pipeline
+
+# A single telemetry channel is a small, uniform feature space, so PCA and
+# KMeans emit benign warnings (near-zero variance, fewer clusters than asked).
+# Detection is unaffected; quiet them for readable benchmark output.
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+warnings.filterwarnings("ignore", category=ConvergenceWarning)
+
+DATA_DIR = Path(os.environ.get("TAD_SMAP_DIR", "")).expanduser()
+LABELS_ENV = os.environ.get("TAD_SMAP_LABELS", "")
+MAX_CHANNELS = int(os.environ.get("TAD_SMAP_MAX_CHANNELS", "0"))  # 0 = all
+
+WINDOW_SIZE = 50
+STEP = 10
+
+
+def find_labels_csv() -> Path | None:
+    if LABELS_ENV:
+        p = Path(LABELS_ENV).expanduser()
+        return p if p.exists() else None
+    for base in (DATA_DIR, *DATA_DIR.parents[:3]):
+        candidate = base / "labeled_anomalies.csv"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def score_channel(chan_id: str, sequences) -> tuple[np.ndarray, np.ndarray] | None:
+    """Return (point_scores, point_truth) for one channel, or None if unusable."""
+    train = pipeline(
+        load_smap(DATA_DIR, [chan_id], split="train", dims="telemetry").to_pandas(),
+        resample_rule=None,
+    )
+    test_df = load_smap(DATA_DIR, [chan_id], split="test", dims="telemetry").to_pandas()
+    n_points = test_df["timestamp"].nunique()
+    test = pipeline(test_df, resample_rule=None)
+
+    X_train = make_feature_table(train, window_size=WINDOW_SIZE, step=STEP)
+    X_test = make_feature_table(test, window_size=WINDOW_SIZE, step=STEP)
+    if X_train.size == 0 or X_test.size == 0:
+        return None
+
+    ensemble = AnomalyEnsemble(
+        models={
+            "pca": PCAAnomaly(n_components=3, scale=True, percentile=95.0),
+            "kmeans": KMeansAnomaly(n_clusters=8, scale=True, percentile=95.0),
+        },
+        combine="mean",
+        normalize="robust",
+        percentile=90.0,
+    )
+    ensemble.fit(X_train)
+    win_scores = ensemble.decision_function(X_test)
+
+    scores = windows_to_point_scores(win_scores, n_points, window_size=WINDOW_SIZE, step=STEP)
+    truth = anomaly_point_mask(sequences, n_points)
+    return scores, truth
+
+
+def main() -> None:
+    labels_csv = find_labels_csv()
+    if not DATA_DIR or not (DATA_DIR / "test").exists() or labels_csv is None:
+        raise SystemExit(
+            "SMAP dataset not found. Set TAD_SMAP_DIR (and optionally "
+            "TAD_SMAP_LABELS). See examples/smap_demo.py for the layout.\n"
+            f"DATA_DIR: {DATA_DIR or '(unset)'}\nlabels: {labels_csv or '(not found)'}"
+        )
+
+    labels = load_smap_labels(labels_csv, spacecraft="SMAP")
+    labels = labels.sort_values("anomaly_span", ascending=False).reset_index(drop=True)
+    if MAX_CHANNELS > 0:
+        labels = labels.head(MAX_CHANNELS)
+
+    print(f"Benchmarking {len(labels)} SMAP channels (window={WINDOW_SIZE}, step={STEP})")
+    print("Metric: best-threshold point-adjusted F1 (standard SMAP protocol)\n")
+    print(f"{'channel':>8}  {'precision':>9}  {'recall':>6}  {'F1':>6}")
+    print("-" * 36)
+
+    all_scores: list[np.ndarray] = []
+    all_truth: list[np.ndarray] = []
+    per_channel_f1: list[float] = []
+    for _, row in labels.iterrows():
+        result = score_channel(row["chan_id"], row["sequences"])
+        if result is None:
+            continue
+        scores, truth = result
+        all_scores.append(scores)
+        all_truth.append(truth)
+        b = best_point_adjusted_f1(scores, truth)
+        per_channel_f1.append(b["f1"])
+        print(f"{row['chan_id']:>8}  {b['precision']:9.3f}  {b['recall']:6.3f}  {b['f1']:6.3f}")
+
+    if not all_scores:
+        raise SystemExit("No channels produced results.")
+
+    scores = np.concatenate(all_scores)
+    truth = np.concatenate(all_truth)
+    overall = best_point_adjusted_f1(scores, truth, n_thresholds=300)
+
+    print("-" * 36)
+    print(
+        f"{'GLOBAL':>8}  {overall['precision']:9.3f}  {overall['recall']:6.3f}  {overall['f1']:6.3f}"
+    )
+    print(
+        f"\nAggregate over {len(all_scores)} channels, {len(truth)} points:"
+        f"\n  best-threshold point-adjusted F1 (single global threshold): {overall['f1']:.3f}"
+        f"  (P={overall['precision']:.3f} R={overall['recall']:.3f})"
+        f"\n  per-channel best F1 (oracle per-channel threshold, upper bound): "
+        f"{np.mean(per_channel_f1):.3f}"
+        f"\n\nNote: the threshold is chosen against the labels (standard SMAP 'best F1'"
+        f"\nprotocol). Report as an oracle upper bound, not a deployed operating point."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/telemetry_anomdet/evaluation.py
+++ b/src/telemetry_anomdet/evaluation.py
@@ -1,0 +1,167 @@
+# src/telemetry_anomdet/evaluation.py
+
+"""
+Point-adjusted evaluation metrics for time-series anomaly detection.
+
+Point adjustment is the standard SMAP / MSL protocol (Xu et al., 2018): if a
+detector flags any point inside a labeled anomaly segment, the whole segment
+counts as detected. It rewards catching an event even when not every point of
+it is flagged, and makes results comparable to the telemanom and MEMTO
+baselines that report point-adjusted F1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+
+def point_adjust(pred: Sequence[bool], truth: Sequence[bool]) -> np.ndarray:
+    """
+    Apply point adjustment to point-level predictions.
+
+    For each contiguous anomaly segment in ``truth``, if ``pred`` flags any point
+    inside it, the entire segment is marked as predicted.
+
+    Arguments:
+        pred: Point-level boolean predictions.
+        truth: Point-level boolean ground truth, same length as ``pred``.
+    Returns:
+        np.ndarray: The adjusted boolean prediction array.
+    """
+
+    pred = np.asarray(pred, dtype=bool).copy()
+    truth = np.asarray(truth, dtype=bool)
+    if pred.shape != truth.shape:
+        raise ValueError(f"pred and truth must match: {pred.shape} vs {truth.shape}")
+
+    n = len(truth)
+    i = 0
+    while i < n:
+        if not truth[i]:
+            i += 1
+            continue
+        j = i
+        while j < n and truth[j]:
+            j += 1
+        if pred[i:j].any():
+            pred[i:j] = True
+        i = j
+    return pred
+
+
+def prf(pred: Sequence[bool], truth: Sequence[bool]) -> dict:
+    """
+    Precision, recall, and F1 for point-level boolean arrays.
+
+    Returns:
+        dict: {'precision', 'recall', 'f1', 'tp', 'fp', 'fn'}.
+    """
+
+    pred = np.asarray(pred, dtype=bool)
+    truth = np.asarray(truth, dtype=bool)
+    tp = int(np.sum(pred & truth))
+    fp = int(np.sum(pred & ~truth))
+    fn = int(np.sum(~pred & truth))
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return {"precision": precision, "recall": recall, "f1": f1, "tp": tp, "fp": fp, "fn": fn}
+
+
+def point_adjusted_f1(pred: Sequence[bool], truth: Sequence[bool]) -> dict:
+    """
+    Point-adjusted precision, recall, and F1 (the standard SMAP metric).
+
+    Equivalent to :func:`prf` computed on :func:`point_adjust` output.
+    """
+
+    return prf(point_adjust(pred, truth), truth)
+
+
+def windows_to_points(
+    window_flags: Sequence[bool], n_points: int, *, window_size: int, step: int
+) -> np.ndarray:
+    """
+    Expand window-level flags to a point-level mask.
+
+    Point ``t`` is flagged if it falls inside any flagged window. Window ``i``
+    spans ``[i*step, i*step + window_size)``, matching ``windowify``.
+
+    Arguments:
+        window_flags: Boolean flag per window.
+        n_points: Length of the point-level series the windows came from.
+        window_size: Samples per window.
+        step: Stride between windows.
+    Returns:
+        np.ndarray: Boolean mask of length ``n_points``.
+    """
+
+    window_flags = np.asarray(window_flags, dtype=bool)
+    points = np.zeros(int(n_points), dtype=bool)
+    for i, flag in enumerate(window_flags):
+        if flag:
+            s = i * step
+            points[s : s + window_size] = True
+    return points
+
+
+def windows_to_point_scores(
+    window_scores: Sequence[float], n_points: int, *, window_size: int, step: int
+) -> np.ndarray:
+    """
+    Expand window-level scores to a point-level score array.
+
+    Each point takes the maximum score among the windows covering it (window
+    ``i`` spans ``[i*step, i*step + window_size)``). Points not covered by any
+    window fall back to the minimum window score.
+
+    Arguments:
+        window_scores: Anomaly score per window (higher = more anomalous).
+        n_points: Length of the point-level series.
+        window_size: Samples per window.
+        step: Stride between windows.
+    Returns:
+        np.ndarray: Float score array of length ``n_points``.
+    """
+    window_scores = np.asarray(window_scores, dtype=float)
+    points = np.full(int(n_points), -np.inf)
+    for i, s in enumerate(window_scores):
+        a = i * step
+        points[a : a + window_size] = np.maximum(points[a : a + window_size], s)
+    fill = window_scores.min() if window_scores.size else 0.0
+    points[~np.isfinite(points)] = fill
+    return points
+
+
+def best_point_adjusted_f1(
+    scores: Sequence[float], truth: Sequence[bool], *, n_thresholds: int = 200
+) -> dict:
+    """
+    Best point-adjusted F1 over a threshold sweep on point-level scores.
+
+    Selects the threshold that maximizes point-adjusted F1. This is the standard
+    SMAP / MSL "best F1" protocol used by telemanom and MEMTO, which makes those
+    baselines comparable. Note that it selects the threshold using the labels, so
+    it should be reported as an oracle-threshold upper bound, not a deployable
+    operating point.
+
+    Arguments:
+        scores: Point-level anomaly scores (higher = more anomalous).
+        truth: Point-level boolean ground truth.
+        n_thresholds: Number of candidate thresholds sampled across the score range.
+    Returns:
+        dict: The best {'precision', 'recall', 'f1', 'tp', 'fp', 'fn', 'threshold'}.
+    """
+    scores = np.asarray(scores, dtype=float)
+    truth = np.asarray(truth, dtype=bool)
+    candidates = np.unique(np.quantile(scores, np.linspace(0.0, 1.0, n_thresholds)))
+    best = {"precision": 0.0, "recall": 0.0, "f1": 0.0, "tp": 0, "fp": 0, "fn": 0}
+    best["threshold"] = float("inf")
+    for t in candidates:
+        m = prf(point_adjust(scores >= t, truth), truth)
+        if m["f1"] > best["f1"]:
+            m["threshold"] = float(t)
+            best = m
+    return best

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,151 @@
+# tests/test_evaluation.py
+
+"""Unit tests for point-adjusted evaluation metrics."""
+
+import numpy as np
+import pytest
+
+from telemetry_anomdet.evaluation import (
+    best_point_adjusted_f1,
+    point_adjust,
+    point_adjusted_f1,
+    prf,
+    windows_to_point_scores,
+    windows_to_points,
+)
+
+# --------------------------------------------------------------------------- #
+# point_adjust
+# --------------------------------------------------------------------------- #
+
+
+def test_point_adjust_expands_hit_segment():
+    truth = [False, True, True, True, False]
+    pred = [False, False, True, False, False]  # one hit inside the segment
+    adjusted = point_adjust(pred, truth)
+    # the whole [1:4) segment becomes predicted
+    assert adjusted.tolist() == [False, True, True, True, False]
+
+
+def test_point_adjust_leaves_missed_segment_alone():
+    truth = [False, True, True, False]
+    pred = [False, False, False, False]  # no hit in the segment
+    assert point_adjust(pred, truth).tolist() == [False, False, False, False]
+
+
+def test_point_adjust_keeps_false_positives_outside_segments():
+    truth = [False, True, True, False, False]
+    pred = [True, False, False, True, False]  # FP at 0 and 3, no hit in segment
+    adjusted = point_adjust(pred, truth)
+    # segment [1:3) not hit -> stays 0; the FPs remain
+    assert adjusted.tolist() == [True, False, False, True, False]
+
+
+def test_point_adjust_handles_segment_at_end():
+    truth = [False, False, True, True]
+    pred = [False, False, False, True]
+    assert point_adjust(pred, truth).tolist() == [False, False, True, True]
+
+
+def test_point_adjust_shape_mismatch_raises():
+    with pytest.raises(ValueError):
+        point_adjust([True, False], [True, False, True])
+
+
+# --------------------------------------------------------------------------- #
+# prf / point_adjusted_f1
+# --------------------------------------------------------------------------- #
+
+
+def test_prf_basic():
+    pred = [True, True, False, False]
+    truth = [True, False, False, True]
+    m = prf(pred, truth)
+    assert m["tp"] == 1 and m["fp"] == 1 and m["fn"] == 1
+    assert m["precision"] == 0.5
+    assert m["recall"] == 0.5
+    assert m["f1"] == 0.5
+
+
+def test_prf_all_zero_predictions():
+    m = prf([False, False], [True, True])
+    assert m["precision"] == 0.0 and m["recall"] == 0.0 and m["f1"] == 0.0
+
+
+def test_point_adjusted_f1_beats_raw_when_partial_hit():
+    truth = [False, True, True, True, False]
+    pred = [False, False, True, False, False]  # 1/3 of the segment hit
+
+    raw = prf(pred, truth)
+    adj = point_adjusted_f1(pred, truth)
+
+    assert raw["recall"] < 1.0  # raw only catches 1 of 3 points
+    assert adj["recall"] == 1.0  # adjustment credits the whole segment
+    assert adj["f1"] >= raw["f1"]
+
+
+# --------------------------------------------------------------------------- #
+# windows_to_points
+# --------------------------------------------------------------------------- #
+
+
+def test_windows_to_points_expands_flags():
+    # window_size=3, step=2. window 1 flagged -> points [2, 3, 4]
+    flags = [False, True, False]
+    pts = windows_to_points(flags, n_points=8, window_size=3, step=2)
+    expected = [False, False, True, True, True, False, False, False]
+    assert pts.tolist() == expected
+
+
+def test_windows_to_points_overlapping_windows_union():
+    # windows overlap; flagged windows 0 and 1 both contribute
+    flags = [True, True]
+    pts = windows_to_points(flags, n_points=6, window_size=3, step=2)
+    # window0 -> [0,1,2], window1 -> [2,3,4]
+    assert pts.tolist() == [True, True, True, True, True, False]
+
+
+def test_windows_to_points_no_flags():
+    pts = windows_to_points([False, False], n_points=5, window_size=2, step=2)
+    assert not pts.any()
+    assert len(pts) == 5
+
+
+# --------------------------------------------------------------------------- #
+# windows_to_point_scores
+# --------------------------------------------------------------------------- #
+
+
+def test_windows_to_point_scores_max_over_covering_windows():
+    # window_size=3, step=2. scores [0.2, 0.9]
+    # window0 covers [0,1,2] with 0.2; window1 covers [2,3,4] with 0.9
+    pts = windows_to_point_scores([0.2, 0.9], n_points=6, window_size=3, step=2)
+    # point 2 is covered by both -> max(0.2, 0.9) = 0.9
+    assert pts[2] == 0.9
+    assert pts[0] == 0.2 and pts[1] == 0.2
+    assert pts[3] == 0.9 and pts[4] == 0.9
+    # point 5 covered by no window -> falls back to min score
+    assert pts[5] == 0.2
+
+
+# --------------------------------------------------------------------------- #
+# best_point_adjusted_f1
+# --------------------------------------------------------------------------- #
+
+
+def test_best_point_adjusted_f1_finds_separating_threshold():
+    # scores cleanly separate anomaly (high) from normal (low)
+    scores = np.array([0.1, 0.2, 0.9, 0.95, 0.15])
+    truth = np.array([False, False, True, True, False])
+    best = best_point_adjusted_f1(scores, truth)
+    assert best["f1"] == 1.0
+    assert 0.2 < best["threshold"] <= 0.9
+
+
+def test_best_point_adjusted_f1_reports_threshold_and_beats_fixed():
+    scores = np.array([0.1, 0.4, 0.5, 0.8, 0.9])
+    truth = np.array([False, True, True, True, False])
+    best = best_point_adjusted_f1(scores, truth)
+    # a good threshold should recover the middle segment with point adjustment
+    assert best["recall"] == 1.0
+    assert "threshold" in best


### PR DESCRIPTION
Adds telemetry_anomdet.evaluation and examples/smap_benchmark.py. Maximized classical baseline: best-threshold point-adjusted F1 0.38 on full SMAP. Threshold selected on labels per the standard SMAP protocol (oracle upper bound).