### PR TITLE
Feature/gdn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,32 @@ jobs:
       - name: Run tests
         run: uv run pytest -q --cov --cov-report=term-missing
 
+  deep-tests:
+    name: Deep Detector Tests
+    needs: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      # The deep extra pulls torch. Install it on a single Python version so the
+      # torch-backed detectors (GDN, ...) are actually exercised rather than
+      # skipped via importorskip, without adding torch to the 4-version matrix.
+      - name: Install dependencies (with deep extra)
+        run: uv sync --group dev --extra deep
+
+      - name: Run deep detector tests
+        run: uv run pytest -q tests/test_deep_gdn.py
+
   docs:
     name: Docs Build
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ classifiers = [
 ccsds = [
   "ccsdspy>=2.0.0,<3.0",
 ]
+# Phase 2 deep detectors (GDN, TranAD). Optional so the base install stays
+# torch-free; torch is imported lazily at fit time.
+deep = [
+  "torch>=2.0",
+]
 
 [dependency-groups]
 dev = [
@@ -51,11 +56,6 @@ docs = [
   "sphinx-autodoc-typehints>=2.0",
   "numpydoc>=1.7",
 ]
-# Phase 2 -- uncomment when GDN/TranAD training starts
-# deep = [
-#   "torch>=2.0",
-#   "torch-geometric",
-# ]
 # Phase 3
 # xai = [
 #   "shap",

--- a/src/telemetry_anomdet/models/__init__.py
+++ b/src/telemetry_anomdet/models/__init__.py
@@ -6,8 +6,9 @@ Models package for telemetry_anomdet.
 Subpackages:
 - supervised: models that require labels (classification/regression).
 - unsupervised: anomaly detection algorithms that operate without labels.
+- deep: sequence-aware detectors (GDN, ...) requiring the optional deep extra.
 """
 
-from . import supervised, unsupervised
+from . import deep, supervised, unsupervised
 
-__all__ = ["supervised", "unsupervised"]
+__all__ = ["deep", "supervised", "unsupervised"]

--- a/src/telemetry_anomdet/models/deep/__init__.py
+++ b/src/telemetry_anomdet/models/deep/__init__.py
@@ -1,0 +1,17 @@
+# src/telemetry_anomdet/models/deep/__init__.py
+
+"""
+Deep, sequence-aware anomaly detection models.
+
+These detectors consume the 3D windowed tensor directly (no feature flattening)
+and require the optional ``deep`` extra (PyTorch)::
+
+    uv sync --extra deep
+
+Importing this subpackage does not import torch; torch is imported lazily when a
+detector is fitted, so the base install can still import the models package.
+"""
+
+from .gdn import GDN
+
+__all__ = ["GDN"]

--- a/src/telemetry_anomdet/models/deep/_net.py
+++ b/src/telemetry_anomdet/models/deep/_net.py
@@ -1,0 +1,159 @@
+# src/telemetry_anomdet/models/deep/_net.py
+
+"""
+Torch network internals for GDN (Graph Deviation Network).
+
+This module imports ``torch`` at the top level and will raise ``ImportError``
+if torch is not installed. It is imported lazily by ``gdn.py`` so that the base
+``telemetry_anomdet`` install (which does not depend on torch) can still import
+the models package. Install the deep extra to use it::
+
+    uv sync --extra deep
+
+The network follows Deng & Hooi (AAAI 2021), "Graph Neural Network-Based
+Anomaly Detection in Multivariate Time Series":
+
+- Each sensor (feature channel) gets a learned embedding ``v_i``.
+- A directed graph is built from the top-k cosine similarities between
+  embeddings (learned structure, recomputed each forward pass).
+- A graph-attention layer aggregates each node's neighbours, with attention
+  conditioned on the node embeddings.
+- A per-node output head forecasts the next value of each sensor.
+
+The detector wrapper (``gdn.py``) turns per-sensor forecast errors into the
+graph deviation anomaly score. This network is intentionally decoupled from the
+``BaseDetector`` API so it can later be consumed on its own (e.g. by a symbolic
+distillation or explainability pass) without dragging in the detector plumbing.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+def topk_graph(embeddings: torch.Tensor, k: int) -> torch.Tensor:
+    """
+    Build a directed top-k similarity graph over node embeddings.
+
+    For each node i, connect it to the k nodes with the highest cosine
+    similarity (excluding itself). Returns a boolean adjacency matrix where
+    ``adj[i, j]`` is True when j is a neighbour of i.
+
+    Parameters
+    ----------
+    embeddings : torch.Tensor, shape (n_nodes, embed_dim)
+        Learned per-sensor embedding vectors.
+    k : int
+        Number of neighbours to retain per node. Clamped to n_nodes - 1.
+
+    Returns
+    -------
+    adj : torch.Tensor of bool, shape (n_nodes, n_nodes)
+    """
+    n_nodes = embeddings.shape[0]
+    k = max(1, min(k, n_nodes - 1))
+
+    normed = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+    sim = normed @ normed.t()  # (n_nodes, n_nodes) cosine similarity
+    sim.fill_diagonal_(float("-inf"))  # never select self
+
+    topk_idx = sim.topk(k, dim=1).indices  # (n_nodes, k)
+    adj = torch.zeros(n_nodes, n_nodes, dtype=torch.bool, device=embeddings.device)
+    adj.scatter_(1, topk_idx, True)
+    return adj
+
+
+class GDNNet(nn.Module):
+    """
+    GDN forecasting network.
+
+    Parameters
+    ----------
+    n_nodes : int
+        Number of sensors / feature channels.
+    window : int
+        Length of the input context per node (window_size - 1 timesteps used
+        to forecast the final timestep).
+    embed_dim : int, default=64
+        Dimensionality of the learned sensor embeddings and hidden features.
+        The node feature transform maps ``window -> embed_dim`` so that the
+        embedding can gate the aggregated representation element-wise.
+    topk : int, default=15
+        Number of graph neighbours per node.
+
+    Notes
+    -----
+    Forward input is ``x`` of shape ``(batch, n_nodes, window)`` and the output
+    is the one-step forecast of shape ``(batch, n_nodes)``.
+    """
+
+    def __init__(self, n_nodes: int, window: int, embed_dim: int = 64, topk: int = 15):
+        super().__init__()
+        self.n_nodes = n_nodes
+        self.window = window
+        self.embed_dim = embed_dim
+        self.topk = topk
+
+        self.embedding = nn.Embedding(n_nodes, embed_dim)
+        # Node feature transform W: raw window values -> hidden features.
+        self.feat = nn.Linear(window, embed_dim)
+        # Attention over the concatenation of the source and target node
+        # descriptors g_i = [v_i | W x_i] (GAT-style, feature- and
+        # embedding-conditioned, per Deng & Hooi eq. 6-8). Input width is
+        # 2 * (embed_dim + embed_dim) = 4 * embed_dim.
+        self.attn = nn.Linear(4 * embed_dim, 1, bias=False)
+        self.leaky = nn.LeakyReLU(0.2)
+        # Per-node output head: gated hidden features -> scalar forecast.
+        self.out = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim),
+            nn.ReLU(),
+            nn.Linear(embed_dim, 1),
+        )
+
+        nn.init.xavier_uniform_(self.embedding.weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forecast the next value for every sensor.
+
+        Parameters
+        ----------
+        x : torch.Tensor, shape (batch, n_nodes, window)
+
+        Returns
+        -------
+        pred : torch.Tensor, shape (batch, n_nodes)
+        """
+        batch, n_nodes, _ = x.shape
+
+        v = self.embedding.weight  # (n_nodes, embed_dim)
+        h = self.feat(x)  # (batch, n_nodes, embed_dim)  == W x_i
+
+        # Learned graph structure from embedding similarity, with self-loops
+        # so each node always attends to itself (paper includes A_ii).
+        adj = topk_graph(v, self.topk)  # (n_nodes, n_nodes) bool
+        adj = adj | torch.eye(n_nodes, dtype=torch.bool, device=x.device)
+
+        # Node descriptor g_i = [v_i | W x_i], broadcast across the batch.
+        vb = v.unsqueeze(0).expand(batch, n_nodes, self.embed_dim)
+        g = torch.cat([vb, h], dim=-1)  # (batch, n_nodes, 2*embed_dim)
+
+        # Pairwise attention logits: pi(i, j) = LeakyReLU(a^T [g_i | g_j]).
+        gi = g.unsqueeze(2).expand(batch, n_nodes, n_nodes, 2 * self.embed_dim)
+        gj = g.unsqueeze(1).expand(batch, n_nodes, n_nodes, 2 * self.embed_dim)
+        scores = self.leaky(self.attn(torch.cat([gi, gj], dim=-1)).squeeze(-1))
+
+        # Mask non-neighbours to -inf, then softmax over source nodes j.
+        mask = adj.unsqueeze(0)  # (1, n_nodes, n_nodes)
+        scores = scores.masked_fill(~mask, float("-inf"))
+        weights = torch.softmax(scores, dim=2)  # (batch, n_nodes, n_nodes)
+
+        # Aggregate neighbour features: z_i = sum_j alpha_ij (W x_j).
+        z = torch.einsum("bij,bjd->bid", weights, h)  # (batch, n_nodes, embed_dim)
+        z = torch.relu(z)
+
+        # Gate aggregated features with the node's own embedding, then forecast.
+        z = z * v.unsqueeze(0)  # broadcast (1, n_nodes, embed_dim)
+        pred = self.out(z).squeeze(-1)  # (batch, n_nodes)
+        return pred

--- a/src/telemetry_anomdet/models/deep/gdn.py
+++ b/src/telemetry_anomdet/models/deep/gdn.py
@@ -1,0 +1,280 @@
+# src/telemetry_anomdet/models/deep/gdn.py
+
+"""
+GDN (Graph Deviation Network) anomaly detector.
+
+A deep, sequence-aware detector that learns a graph over sensor channels and
+forecasts each channel one step ahead. Anomaly scores are the *graph deviation
+score*: the maximum, over sensors, of each sensor's forecast error normalised by
+its training-error statistics.
+
+Reference: Deng & Hooi, "Graph Neural Network-Based Anomaly Detection in
+Multivariate Time Series", AAAI 2021.
+
+Unlike the classical detectors, GDN is a *sequence* detector: it consumes the 3D
+windowed tensor ``(n_windows, window_size, n_features)`` directly rather than
+flattening it via ``features_stat()``. The first ``window_size - 1`` timesteps of
+each window are the forecasting context and the final timestep is the target.
+
+torch is an optional dependency. Install the deep extra to use this detector::
+
+    uv sync --extra deep
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..base import BaseDetector
+
+
+def _import_torch():
+    """
+    Import torch, raising a friendly error if the deep extra is not installed.
+    """
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover - exercised only without torch
+        raise ImportError(
+            "GDN requires PyTorch, which is an optional dependency. "
+            "Install it with the deep extra:\n\n    uv sync --extra deep\n\n"
+            "or:  pip install 'telemetry-anomdet[deep]'"
+        ) from exc
+    return torch
+
+
+class GDN(BaseDetector):
+    """
+    Graph Deviation Network detector.
+
+    Parameters
+    ----------
+    embed_dim : int, default=64
+        Dimensionality of the learned per-sensor embeddings and hidden features.
+    topk : int, default=15
+        Number of graph neighbours retained per sensor. Clamped internally to
+        ``n_features - 1``.
+    epochs : int, default=30
+        Number of training epochs.
+    batch_size : int, default=64
+        Minibatch size for training.
+    lr : float, default=1e-3
+        Adam learning rate.
+    device : str or None, default=None
+        Torch device string (e.g. "cuda", "cpu"). If None, uses CUDA when
+        available, otherwise CPU.
+    random_state : int or None, default=None
+        Seed for torch and numpy RNGs, for reproducible training.
+    percentile : float, default=95.0
+        Percentile of training deviation scores used to set ``threshold_``.
+
+    Attributes (set after fit)
+    --------------------------
+    decision_scores_ : np.ndarray, shape (n_windows,)
+        Graph deviation scores on the training data.
+    threshold_ : float
+        Default anomaly cutoff derived from training scores at ``percentile``.
+    labels_ : np.ndarray, shape (n_windows,)
+        Binary anomaly labels on training data. 0 = normal, 1 = anomaly.
+    net : GDNNet
+        The fitted torch forecasting network.
+    n_nodes_ : int
+        Number of sensor channels seen during fit.
+    window_ : int
+        Forecasting context length (window_size - 1).
+
+    Notes
+    -----
+    The internal torch network is kept deliberately separate from this wrapper
+    (see ``_net.GDNNet``) so it can be consumed on its own by later
+    explainability or symbolic-distillation work without the detector plumbing.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int = 64,
+        topk: int = 15,
+        epochs: int = 30,
+        batch_size: int = 64,
+        lr: float = 1e-3,
+        device: str | None = None,
+        random_state: int | None = None,
+        percentile: float = 95.0,
+    ):
+        super().__init__(percentile=percentile)
+        self.embed_dim = embed_dim
+        self.topk = topk
+        self.epochs = epochs
+        self.batch_size = batch_size
+        self.lr = lr
+        self.device = device
+        self.random_state = random_state
+
+        # Fit artifacts: set in fit()
+        self.net = None
+        self.n_nodes_: int | None = None
+        self.window_: int | None = None
+        self._err_median_: np.ndarray | None = None
+        self._err_iqr_: np.ndarray | None = None
+
+    # ---- helpers ----
+    def _resolve_device(self, torch):
+        if self.device is not None:
+            return torch.device(self.device)
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    @staticmethod
+    def _split_context_target(X: np.ndarray):
+        """
+        Split windows into forecasting context and target.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape (n_windows, window_size, n_features)
+
+        Returns
+        -------
+        context : np.ndarray, shape (n_windows, n_features, window_size - 1)
+            Per-node input sequences (transposed so nodes lead the sequence).
+        target : np.ndarray, shape (n_windows, n_features)
+            Final-timestep value for each node.
+        """
+        context = np.transpose(X[:, :-1, :], (0, 2, 1))  # (n, n_features, w-1)
+        target = X[:, -1, :]  # (n, n_features)
+        return context, target
+
+    def _forecast_errors(self, X: np.ndarray) -> np.ndarray:
+        """
+        Per-window, per-node absolute forecast error, shape (n_windows, n_nodes).
+        """
+        torch = _import_torch()
+        context, target = self._split_context_target(X)
+        device = next(self.net.parameters()).device
+
+        self.net.eval()
+        errors = []
+        with torch.no_grad():
+            for start in range(0, context.shape[0], self.batch_size):
+                xb = torch.as_tensor(
+                    context[start : start + self.batch_size], dtype=torch.float32, device=device
+                )
+                pred = self.net(xb).cpu().numpy()
+                tb = target[start : start + self.batch_size]
+                errors.append(np.abs(pred - tb))
+        return np.concatenate(errors, axis=0)
+
+    def _deviation_score(self, errors: np.ndarray) -> np.ndarray:
+        """
+        Collapse per-node errors to a single graph deviation score per window.
+
+        Each node's error is normalised by its training median and IQR, then the
+        maximum across nodes is taken (the sensor deviating most drives the
+        window score).
+        """
+        normed = np.abs(errors - self._err_median_) / (self._err_iqr_ + 1e-9)
+        return normed.max(axis=1)
+
+    def fit(self, X: np.ndarray, y: np.ndarray | None = None) -> GDN:
+        """
+        Fit the GDN forecasting network on nominal telemetry windows.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape (n_windows, window_size, n_features)
+            Windowed telemetry tensor from windowify(). ``window_size`` must be
+            at least 2 (one context step plus one target step).
+        y : ignored
+            Present for API consistency.
+
+        Returns
+        -------
+        self : GDN
+        """
+        torch = _import_torch()
+        from ._net import GDNNet
+
+        X = self._validate_X(X)
+        if X.shape[1] < 2:
+            raise ValueError(
+                f"GDN needs window_size >= 2 (context + target), got window_size = {X.shape[1]}."
+            )
+
+        if self.random_state is not None:
+            torch.manual_seed(self.random_state)
+            np.random.seed(self.random_state)
+
+        self.n_nodes_ = X.shape[2]
+        self.window_ = X.shape[1] - 1
+        device = self._resolve_device(torch)
+
+        context, target = self._split_context_target(X)
+        ctx_t = torch.as_tensor(context, dtype=torch.float32)
+        tgt_t = torch.as_tensor(target, dtype=torch.float32)
+        dataset = torch.utils.data.TensorDataset(ctx_t, tgt_t)
+        loader = torch.utils.data.DataLoader(dataset, batch_size=self.batch_size, shuffle=True)
+
+        self.net = GDNNet(
+            n_nodes=self.n_nodes_,
+            window=self.window_,
+            embed_dim=self.embed_dim,
+            topk=self.topk,
+        ).to(device)
+
+        optimizer = torch.optim.Adam(self.net.parameters(), lr=self.lr)
+        loss_fn = torch.nn.MSELoss()
+
+        self.net.train()
+        for _ in range(self.epochs):
+            for xb, tb in loader:
+                xb = xb.to(device)
+                tb = tb.to(device)
+                optimizer.zero_grad()
+                pred = self.net(xb)
+                loss = loss_fn(pred, tb)
+                loss.backward()
+                optimizer.step()
+
+        # Per-node training-error statistics for deviation normalisation.
+        errors = self._forecast_errors(X)  # (n_windows, n_nodes)
+        self._err_median_ = np.median(errors, axis=0)
+        q75, q25 = np.percentile(errors, [75, 25], axis=0)
+        self._err_iqr_ = q75 - q25
+
+        scores = self._deviation_score(errors)
+        self._set_post_fit(scores)
+        return self
+
+    def decision_function(self, X: np.ndarray) -> np.ndarray:
+        """
+        Compute the graph deviation score for each window.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape (n_windows, window_size, n_features)
+
+        Returns
+        -------
+        scores : np.ndarray, shape (n_windows,)
+            Graph deviation scores. Higher = more anomalous.
+        """
+        self._require_fit()
+        X = self._validate_X(X)
+        if X.shape[2] != self.n_nodes_:
+            raise ValueError(f"X has {X.shape[2]} features but GDN was fitted on {self.n_nodes_}.")
+        if X.shape[1] - 1 != self.window_:
+            raise ValueError(
+                f"X has window_size {X.shape[1]} but GDN was fitted on "
+                f"window_size {self.window_ + 1}."
+            )
+        errors = self._forecast_errors(X)
+        return self._deviation_score(errors)
+
+    def _get_params(self) -> dict:
+        return {
+            "embed_dim": self.embed_dim,
+            "topk": self.topk,
+            "epochs": self.epochs,
+            "batch_size": self.batch_size,
+            "lr": self.lr,
+            "percentile": self.percentile,
+        }

--- a/tests/test_deep_gdn.py
+++ b/tests/test_deep_gdn.py
@@ -1,0 +1,163 @@
+import numpy as np
+import pytest
+
+# GDN needs the optional deep extra (torch). Skip the whole module if absent.
+pytest.importorskip("torch")
+
+from telemetry_anomdet.models.deep.gdn import GDN  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_series(rng, n_windows, window_size=10, n_features=4, scale=1.0, shift=0.0):
+    """Smooth per-window sequences so forecasting has signal to learn."""
+    base = rng.normal(shift, scale, size=(n_windows, 1, n_features))
+    noise = rng.normal(0, 0.05, size=(n_windows, window_size, n_features))
+    ramp = np.linspace(0, 1, window_size)[None, :, None]
+    return base + ramp * base * 0.1 + noise
+
+
+def fast_gdn(**kw):
+    kw.setdefault("epochs", 3)
+    kw.setdefault("embed_dim", 16)
+    kw.setdefault("topk", 3)
+    kw.setdefault("random_state", 0)
+    return GDN(**kw)
+
+
+# ---------------------------------------------------------------------------
+# Smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_gdn_basic_fit_and_scores():
+    rng = np.random.default_rng(0)
+    X_train = make_series(rng, 120)
+    X_test = make_series(rng, 20)
+
+    det = fast_gdn().fit(X_train)
+    scores = det.decision_function(X_test)
+
+    assert scores.shape == (20,)
+    assert scores.dtype.kind == "f"
+    assert np.isfinite(scores).all()
+
+
+# ---------------------------------------------------------------------------
+# Post-fit attributes
+# ---------------------------------------------------------------------------
+
+
+def test_gdn_postfit_attributes():
+    rng = np.random.default_rng(1)
+    X = make_series(rng, 100)
+    det = fast_gdn(percentile=95.0).fit(X)
+
+    assert det.decision_scores_ is not None
+    assert det.decision_scores_.shape == (100,)
+    assert isinstance(det.threshold_, float)
+    assert set(det.labels_).issubset({0, 1})
+    assert det.n_nodes_ == 4
+    assert det.window_ == 9  # window_size - 1
+
+
+# ---------------------------------------------------------------------------
+# predict returns binary labels
+# ---------------------------------------------------------------------------
+
+
+def test_gdn_predict_returns_binary():
+    rng = np.random.default_rng(2)
+    X = make_series(rng, 80)
+    det = fast_gdn().fit(X)
+    preds = det.predict(X)
+    assert preds.shape == (80,)
+    assert set(preds).issubset({0, 1})
+
+
+# ---------------------------------------------------------------------------
+# Anomalous windows score higher
+# ---------------------------------------------------------------------------
+
+
+def test_gdn_anomalous_scores_higher():
+    rng = np.random.default_rng(3)
+    X_train = make_series(rng, 200, scale=1.0)
+    X_normal = make_series(rng, 40, scale=1.0)
+    X_anom = make_series(rng, 40, scale=1.0, shift=8.0)  # off-distribution level
+
+    det = fast_gdn(epochs=8).fit(X_train)
+
+    assert det.decision_function(X_anom).mean() > det.decision_function(X_normal).mean()
+
+
+# ---------------------------------------------------------------------------
+# Determinism with a fixed seed
+# ---------------------------------------------------------------------------
+
+
+def test_gdn_reproducible_with_seed():
+    rng = np.random.default_rng(4)
+    X = make_series(rng, 80)
+
+    a = fast_gdn(random_state=123).fit(X).decision_scores_
+    b = fast_gdn(random_state=123).fit(X).decision_scores_
+    np.testing.assert_allclose(a, b)
+
+
+# ---------------------------------------------------------------------------
+# is_anomaly overrides (inherited from BaseDetector)
+# ---------------------------------------------------------------------------
+
+
+def test_gdn_is_anomaly_threshold_override():
+    rng = np.random.default_rng(5)
+    X = make_series(rng, 80)
+    det = fast_gdn().fit(X)
+
+    assert det.is_anomaly(X, threshold=-999.0).all()
+    assert not det.is_anomaly(X, threshold=1e9).any()
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def test_gdn_rejects_2d_input():
+    rng = np.random.default_rng(6)
+    det = fast_gdn().fit(make_series(rng, 50))
+    with pytest.raises(ValueError, match="3D"):
+        det.decision_function(np.ones((50, 4)))
+
+
+def test_gdn_rejects_window_size_1():
+    det = fast_gdn()
+    with pytest.raises(ValueError, match="window_size >= 2"):
+        det.fit(np.ones((20, 1, 4)))
+
+
+def test_gdn_rejects_feature_mismatch():
+    rng = np.random.default_rng(7)
+    det = fast_gdn().fit(make_series(rng, 50, n_features=4))
+    with pytest.raises(ValueError, match="fitted on 4"):
+        det.decision_function(make_series(rng, 10, n_features=5))
+
+
+def test_gdn_requires_fit_before_decision():
+    with pytest.raises(RuntimeError, match="not fitted"):
+        GDN().decision_function(np.ones((10, 5, 4)))
+
+
+# ---------------------------------------------------------------------------
+# Repr
+# ---------------------------------------------------------------------------
+
+
+def test_gdn_repr():
+    det = fast_gdn()
+    assert "fitted=False" in repr(det)
+    det.fit(make_series(np.random.default_rng(0), 40))
+    assert "fitted=True" in repr(det)

--- a/uv.lock
+++ b/uv.lock
@@ -428,6 +428,85 @@ toml = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/1f/5ef51f5fbaa5d4d3201bb3d7555af028ec1aa4416275ccbf73c9e34e3d2d/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9851b0caa8bfd3bc6fa054eaf57bea7c8e9c3a62db2d2621224677f49f3c53d0", size = 6675244, upload-time = "2026-05-29T23:11:38.664Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl", hash = "sha256:1503af579d8379c24bdd65528379bc57039b0455be9f5f9686cf8e473a1fce51", size = 54591, upload-time = "2026-07-21T15:03:56.224Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cusolver = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -480,6 +559,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
 ]
 
 [[package]]
@@ -625,12 +713,46 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -803,6 +925,158 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/3c/dfccc9e7dee357fb2aa13c3890d952a370dd0ed071e0f7ed62ed0df567c1/numpydoc-1.10.0.tar.gz", hash = "sha256:3f7970f6eee30912260a6b31ac72bba2432830cd6722569ec17ee8d3ef5ffa01", size = 94027, upload-time = "2025-12-02T16:39:12.937Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl", hash = "sha256:3149da9874af890bcc2a82ef7aae5484e5aa81cb2778f08e3c307ba6d963721b", size = 69255, upload-time = "2025-12-02T16:39:11.561Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.3.33"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -1382,6 +1656,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1623,6 +1906,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "telemetry-anomdet"
 version = "0.1.0"
 source = { editable = "." }
@@ -1639,6 +1934,9 @@ dependencies = [
 [package.optional-dependencies]
 ccsds = [
     { name = "ccsdspy" },
+]
+deep = [
+    { name = "torch" },
 ]
 
 [package.dev-dependencies]
@@ -1667,9 +1965,10 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.1,<3.0" },
     { name = "pandas", specifier = ">=2.2.2,<3.0.0" },
     { name = "scikit-learn", specifier = ">=1.3,<2.0" },
+    { name = "torch", marker = "extra == 'deep'", specifier = ">=2.0" },
     { name = "typing-extensions", specifier = ">=4.16.0" },
 ]
-provides-extras = ["ccsds"]
+provides-extras = ["ccsds", "deep"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1747,6 +2046,73 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/e7/19894fdb51c7dbaf94f5a79bb0871da0992e8e4241e579cb006da46d2e58/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:94f0de129916f77b8dc2c7a8eff644cfeddfe59e39c9f55e9f6e17543410281d", size = 111178962, upload-time = "2026-07-08T16:05:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/5c/b1d5de470c54e339b30a92d96683a71bcebd78f5f2a7fc714cd6dc6bbd68/torch-2.13.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:0ab4b69f3ee03a62a002cfbf77b1ca5e88aceb4ea64cb4388bb28f638ddbb045", size = 427198333, upload-time = "2026-07-08T16:05:36.847Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c0/68a84105e1fcb8970144b388ff3d3e5dc15a3be28c1e247841f7d7247e41/torch-2.13.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c78b7b4d04461855a764cf01bae9a462bb88bc93defcfa11235cbc8fdf3e12c4", size = 526555154, upload-time = "2026-07-08T16:05:06.507Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c9/0bb9d097b03cbaf96bb75b15e867347b8e41bfcdfe0539452d17d9e63993/torch-2.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:2bd30b6b730d987fa386ce3898933762c5cb8cc82eb0535211d787cc3ce2dfeb", size = 122015602, upload-time = "2026-07-08T16:05:45.25Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/fe/cba54dc58523434919b66f13a667e36e436deddd77ca519e96553617d4ec/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", size = 111187938, upload-time = "2026-07-08T16:05:17.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/59/1e3160e18e12aa3038390efab3ce02b36a9d4d6a527ecdd8520dca2e68d8/torch-2.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:092790c696a760c729fd5722835f50b9d81fd7c8f141571f3f3cf4081a8f664c", size = 427199369, upload-time = "2026-07-08T16:04:51.054Z" },
+    { url = "https://files.pythonhosted.org/packages/01/79/1f2d34ad7034ee1c7ffc1cf8bf0f8213af2a81df6ecdb3997ecec107c09d/torch-2.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:60fcdcb2f3876e21146cb4524ef06397d727ca9ad5f020818547e25075fe3cb7", size = 526574961, upload-time = "2026-07-08T16:04:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/0f2ce40f58aefbdb3392f9acce3c8171940943ae2d661f70558bfa73befb/torch-2.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0d8b11f16a48d60e2015d8213aa0390744cbebb98e58b62b3514dddc656e330", size = 122015870, upload-time = "2026-07-08T16:05:27.59Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/ea/629cc37436ca5df93ce98956d09cd2ca1498bfee8ef4972d2fe48b9f958c/triton-3.7.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3daf64305d6cea88d3334c65ebc9bcd0c64c9564a977084366aa768d57cbcf64", size = 184551013, upload-time = "2026-06-17T20:03:37.551Z" },
+    { url = "https://files.pythonhosted.org/packages/15/76/c79c34311625227a288df3e483fc5cdf3d596624cbd4b4758c4cbdc14af3/triton-3.7.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee89fbf782ec2ad50391dd1cf26cbea4f4467154c37f4773026da8fc31c0f58e", size = 197596267, upload-time = "2026-06-17T19:53:06.898Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f9/19d842d06a08559534fa1eaab6ca551b1bcf40f06620bddec1babaa2772d/triton-3.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a0e1cd4c4a76370ed74a8432a53cea28716827d19e40ffc732233e35ceb3f6", size = 184664887, upload-time = "2026-06-17T20:03:42.913Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5e/fce69606f7f240297f163e25539906732b199530d486ce67ae319877e821/triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6744957e9fd610a29680ec2346057d0c86948ed3812468670719f391e94b44a5", size = 197701306, upload-time = "2026-06-17T19:53:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
First Phase 2 deep detector for 0.2.0: **GDN (Graph Deviation Network)**, from Deng & Hooi (AAAI 2021).

- `models/deep/_net.py` - isolated `GDNNet`: learned sensor embeddings, top-k similarity graph with self-loops, feature-conditioned graph attention (`g_i = [v_i | Wx_i]`), per-sensor one-step forecast head.
- `models/deep/gdn.py` - `GDN(BaseDetector)`: lazy torch import, graph-deviation scoring (max normalized per-sensor forecast error), standard `fit`/`decision_function`/post-fit attributes.
- `deep = ["torch>=2.0"]` optional extra; base install remains torch-free (verified).

## Testing
- `tests/test_deep_gdn.py`: 11 tests, `importorskip("torch")` - train/score, reproducible-with-seed, anomalous-scores-higher, input validation.
- Full suite green locally (125 passed). Lint + format clean.

## CI note
`test_deep_gdn.py` **skips unless the deep extra is installed**. CI must run `uv sync --extra deep` for these to execute.

## Not in this PR (follow-ups)
- Benchmark integration (needs the 3D `windowify` path; GDN bypasses `make_feature_table`).
- TranAD detector.